### PR TITLE
refactor: Remove non-specified projects from projects page

### DIFF
--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -1,71 +1,45 @@
-
 import { ProjectCardProps } from '@/components/ProjectCard';
 
 // Mock data for projects
 export const projectsData: ProjectCardProps[] = [
   {
     id: 1,
-    title: "Sales Performance Dashboard",
-    description: "Interactive dashboard visualizing sales data across regions with key performance indicators and trend analysis.",
-    image: "https://images.unsplash.com/photo-1551288049-bebda4e38f71?auto=format&fit=crop&q=80&w=1000",
-    tags: ["Tableau", "Data Visualization", "Sales Analytics"],
-    githubUrl: "https://github.com/username/sales-dashboard",
-    demoUrl: "https://example.com/demo1"
+    title: "Excel Sales Analysis",
+    description: "This project showcases proficiency in using Microsoft Excel for comprehensive sales data analysis. It covers the process from data cleaning and preparation to deriving insights using Pivot Tables and creating visualizations directly within Excel.",
+    image: "https://images.unsplash.com/photo-1542744173-8e7e53415bb0?auto=format&fit=crop&q=80&w=1000",
+    tags: ["Excel", "Data Cleaning", "Pivot Tables", "Data Visualization", "Excel Functions"],
+    githubUrl: "https://github.com/shanderson10/Excel-Sales-Analysis"
   },
   {
     id: 2,
-    title: "Customer Segmentation Analysis",
-    description: "Implemented clustering algorithms to segment customers based on purchasing behavior and demographic data.",
-    image: "https://images.unsplash.com/photo-1551434678-e076c223a692?auto=format&fit=crop&q=80&w=1000",
-    tags: ["Python", "Machine Learning", "Customer Analytics"],
-    githubUrl: "https://github.com/username/customer-segmentation"
+    title: "Capturing & Analyzing Live Stock Data",
+    description: "This project explores methods for capturing live stock market data and applying statistical techniques to analyze it. The focus is on understanding stock behavior through descriptive statistics and potentially informing trading decisions using prescriptive insights.",
+    image: "https://images.unsplash.com/photo-1542744173-8e7e53415bb0?auto=format&fit=crop&q=80&w=1000",
+    tags: ["Descriptive Statistics", "Prescriptive Statistics", "Data Interpretation", "Python", "Pandas", "NumPy", "SciPy"],
+    githubUrl: "https://github.com/shanderson10/Capturing-Live-Stock-Data"
   },
   {
     id: 3,
-    title: "Financial Forecasting Model",
-    description: "Developed a time-series forecasting model to predict financial performance and support budget planning.",
-    image: "https://images.unsplash.com/photo-1460925895917-afdab827c52f?auto=format&fit=crop&q=80&w=1000",
-    tags: ["Excel", "Financial Analysis", "Forecasting"],
-    githubUrl: "https://github.com/username/financial-forecasting"
+    title: "Customer Statistics & Superstore Sales Analysis",
+    description: "This project delves into customer behavior and sales performance within a superstore dataset. The analysis focuses on identifying key customer segments, understanding purchasing patterns, and visualizing sales trends using Tableau.",
+    image: "https://images.unsplash.com/photo-1542744173-8e7e53415bb0?auto=format&fit=crop&q=80&w=1000",
+    tags: ["Tableau", "Exploratory Data Analysis (EDA)", "Data Visualization", "Customer Segmentation", "Sales Analysis"],
+    githubUrl: "https://github.com/shanderson10/Customer-Statistics-Superstore-Sales"
   },
   {
     id: 4,
-    title: "Supply Chain Optimization",
-    description: "Analyzed supply chain data to identify bottlenecks and optimize inventory management processes.",
-    image: "https://images.unsplash.com/photo-1566073771259-6a8506099945?auto=format&fit=crop&q=80&w=1000",
-    tags: ["SQL", "Supply Chain", "Optimization"],
-    githubUrl: "https://github.com/username/supply-chain-optimization"
+    title: "Descriptive Statistics for Nutrient Analysis",
+    description: "This project explores the nutritional composition of 10 items using descriptive statistics to gain meaningful insights. The analysis covers distribution, central tendencies, dispersion, and various visualizations.",
+    image: "https://images.unsplash.com/photo-1542744173-8e7e53415bb0?auto=format&fit=crop&q=80&w=1000",
+    tags: ["Python", "Jupyter Notebook", "Descriptive Statistics", "Data Visualization", "Pandas", "NumPy", "Matplotlib", "Seaborn"],
+    githubUrl: "https://github.com/shanderson10/Descriptive-Statistics"
   },
   {
     id: 5,
-    title: "Marketing Campaign Effectiveness",
-    description: "Evaluated the ROI of marketing campaigns across different channels and customer segments.",
-    image: "https://images.unsplash.com/photo-1563986768609-322da13575f3?auto=format&fit=crop&q=80&w=1000",
-    tags: ["Marketing Analytics", "ROI Analysis", "Data Visualization"],
-    githubUrl: "https://github.com/username/marketing-effectiveness"
-  },
-  {
-    id: 6,
-    title: "Churn Prediction Model",
-    description: "Built a machine learning model to predict customer churn and identify factors contributing to attrition.",
-    image: "https://images.unsplash.com/photo-1551434678-e076c223a692?auto=format&fit=crop&q=80&w=1000",
-    tags: ["Python", "Machine Learning", "Customer Analytics"],
-    githubUrl: "https://github.com/username/churn-prediction"
-  },
-  {
-    id: 7,
-    title: "HR Analytics Dashboard",
-    description: "Created a comprehensive dashboard to track employee performance, retention, and satisfaction metrics.",
-    image: "https://images.unsplash.com/photo-1529119513321-989c92d50ce0?auto=format&fit=crop&q=80&w=1000",
-    tags: ["Tableau", "HR Analytics", "Data Visualization"],
-    githubUrl: "https://github.com/username/hr-analytics"
-  },
-  {
-    id: 8,
-    title: "Product Recommendation Engine",
-    description: "Developed a collaborative filtering algorithm to generate personalized product recommendations.",
+    title: "City Rankings and Health Metrics Analysis",
+    description: "This project explores the relationship between city rankings, happiness levels, and health metrics such as obesity and life expectancy. It aims to uncover patterns and insights that can guide urban planning and public health initiatives.",
     image: "https://images.unsplash.com/photo-1542744173-8e7e53415bb0?auto=format&fit=crop&q=80&w=1000",
-    tags: ["Python", "Machine Learning", "Recommendation Systems"],
-    githubUrl: "https://github.com/username/recommendation-engine"
+    tags: ["Python", "Pandas", "Matplotlib", "Seaborn", "Colab", "Data Analysis", "Data Visualization", "Statistical Analysis"],
+    githubUrl: "https://github.com/shanderson10/City-Rankings-and-Health-Metrics"
   }
 ];


### PR DESCRIPTION
I've updated the `src/data/projects.ts` file to only include the projects that you explicitly provided. Projects not in your specified list have been removed.

The IDs of the remaining projects have been re-sequenced to ensure they are continuous. This change addresses your feedback to curate the project list to the five specified GitHub repositories.